### PR TITLE
Link to Universal Team website in footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,7 +1,7 @@
 <footer class="bg-dark">
 	<div class="container">
 		<p class="text-light">
-			By: <a href="https://github.com/Universal-Team" class="link">Universal-Team</a><br>
+			By: <a href="https://universal-team.net/" class="link">Universal-Team</a><br>
 			Published with <a href="https://pages.github.com">GitHub Pages</a>, view <a href="https://github.com/{{ site.repo }}">the source</a> on GitHub.
 		</p>
 	</div>


### PR DESCRIPTION
Replaces the Github Organization Link