### PR TITLE
Fix `GodMode9i.cia` extraction

### DIFF
--- a/source/source.json
+++ b/source/source.json
@@ -341,6 +341,13 @@
 				{
 					"type": "extractFile",
 					"file": "/GodMode9i.7z",
+					"input": "GodMode9i.nds",
+					"output": "/GodMode9i.nds",
+					"message": "Extracting GodMode9i.nds..."
+				},
+				{
+					"type": "extractFile",
+					"file": "/GodMode9i.7z",
 					"input": "GodMode9i.cia",
 					"output": "/GodMode9i.cia",
 					"message": "Extracting GodMode9i.cia..."
@@ -393,6 +400,13 @@
 					"file": "https://github.com/TWLBot/Builds/raw/master/extras/GodMode9i.7z",
 					"output": "/GodMode9i.7z",
 					"message": "Downloading GodMode9i.7z..."
+				},
+				{
+					"type": "extractFile",
+					"file": "/GodMode9i.7z",
+					"input": "GodMode9i/GodMode9i.nds",
+					"output": "/GodMode9i.nds",
+					"message": "Extracting GodMode9i.nds..."
 				},
 				{
 					"type": "extractFile",


### PR DESCRIPTION
As of 3.0.0 GM9i requires GodMode9i.nds on root.