### PR TITLE
Exclude dfc from UniStore

### DIFF
--- a/source/source.json
+++ b/source/source.json
@@ -3139,7 +3139,8 @@
 		"systems": ["DS"],
 		"categories": ["utility"],
 		"image": "https://raw.githubusercontent.com/Epicpkmn11/dfc/master/resources/banner.png",
-		"icon": "https://raw.githubusercontent.com/Epicpkmn11/dfc/master/resources/icon.png"
+		"icon": "https://raw.githubusercontent.com/Epicpkmn11/dfc/master/resources/icon.png",
+		"unistore_exclude": true
 	},
 	{
 		"title": "TWiLight Menu++",


### PR DESCRIPTION
This is a hiyaCFW helper application which isn't supported on 3DS.
Though personally I think it should be removed entirely(?)