### PR TITLE
Revert "Fix install location for Trogdor: Reburninated"

### DIFF
--- a/source/source.json
+++ b/source/source.json
@@ -5610,7 +5610,7 @@
 		"long_description": "An enhanced recreation of the Homestar Runner Flash game, \"Trogdor\", expanded with new features.\n- New Options menu to customize your game\n- Level select\n- New cheats\n- Optional soundtrack from Stinkoman 20X6, another Homestar Runner game\n- Multiple screen scaling options\n- Bugs from the original game have been fixed",
 		"archive": {
 			"Trogdor-Reburninated-(.*)-3ds\\.zip": {
-				"Trogdor-Reburninated.3dsx": ["Trogdor-RB"]
+				"Trogdor-Reburninated.3dsx": ["3ds"]
 			}
 		}
 	},


### PR DESCRIPTION
Didn't fix the problem.

**Before:** Trogdor-RB folder installed to sdmc:/3ds/3ds (incorrect, causes crash on launch)
**After:** It installs to the root of SD card (also incorrect, causes crash on launch).

The correct location for Trogdor-RB is sdmc:/3ds. At that location, the game works, but I don't know how to make Universal Updater install it there.