### PR TITLE
Re-add Local SatellaZone

### DIFF
--- a/source/source.json
+++ b/source/source.json
@@ -5254,6 +5254,100 @@
 					"type": "promptMessage",
 					"message": "Ensure \"Enable game patching\" is enabled\nin Luma3DS settings for this to work."
 				}
+			],
+			"[local] EUR": [
+				{
+					"type": "rmdir",
+					"directory": "/luma/titles/0004001000022B00/romfs"
+				},
+				{
+					"type": "downloadRelease",
+					"repo": "MegaPika/SatellaZone",
+					"file": "LocalSatellaZone.zip",
+					"output": "/LocalSatellaZone.zip"
+				},
+				{
+					"type": "extractFile",
+					"file": "/LocalSatellaZone.zip",
+					"input": "",
+					"output": "/luma/titles/0004001000022B00/"
+				},
+				{
+					"type": "deleteFile",
+					"file": "/LocalSatellaZone.zip"
+				},
+				{
+					"type": "promptMessage",
+					"message": "Ensure \"Enable game patching\" is enabled\nin Luma3DS settings for this to work."
+				}
+			],
+			"[local] USA": [
+				{
+					"type": "rmdir",
+					"directory": "/luma/titles/0004001000021B00/romfs"
+				},
+				{
+					"type": "downloadRelease",
+					"repo": "MegaPika/SatellaZone",
+					"file": "LocalSatellaZone.zip",
+					"output": "/LocalSatellaZone.zip"
+				},
+				{
+					"type": "downloadRelease",
+					"repo": "MegaPika/SatellaZone",
+					"file": "UsaPatch.zip",
+					"output": "/UsaPatch.zip"
+				},
+				{
+					"type": "extractFile",
+					"file": "/LocalSatellaZone.zip",
+					"input": "",
+					"output": "/luma/titles/0004001000021B00/"
+				},
+				{
+					"type": "extractFile",
+					"file": "/UsaPatch.zip",
+					"input": "",
+					"output": "/"
+				},
+				{
+					"type": "deleteFile",
+					"file": "/LocalSatellaZone.zip"
+				},
+				{
+					"type": "deleteFile",
+					"file": "/UsaPatch.zip"
+				},
+				{
+					"type": "promptMessage",
+					"message": "Ensure \"Enable game patching\" is enabled\nin Luma3DS settings for this to work."
+				}
+			],
+			"[local] JPN": [
+				{
+					"type": "rmdir",
+					"directory": "/luma/titles/0004001000020B00/romfs"
+				},
+				{
+					"type": "downloadRelease",
+					"repo": "MegaPika/SatellaZone",
+					"file": "LocalSatellaZone.zip",
+					"output": "/LocalSatellaZone.zip"
+				},
+				{
+					"type": "extractFile",
+					"file": "/LocalSatellaZone.zip",
+					"input": "",
+					"output": "/luma/titles/0004001000020B00/"
+				},
+				{
+					"type": "deleteFile",
+					"file": "/LocalSatellaZone.zip"
+				},
+				{
+					"type": "promptMessage",
+					"message": "Ensure \"Enable game patching\" is enabled\nin Luma3DS settings for this to work."
+				}
 			]
 		}
 	},

--- a/source/source.json
+++ b/source/source.json
@@ -5175,7 +5175,7 @@
 				{
 					"type": "extractFile",
 					"file": "/SatellaZone.zip",
-					"input": "SatellaZone/",
+					"input": "",
 					"output": "/luma/titles/0004001000022B00/"
 				},
 				{
@@ -5207,7 +5207,7 @@
 				{
 					"type": "extractFile",
 					"file": "/SatellaZone.zip",
-					"input": "SatellaZone/",
+					"input": "",
 					"output": "/luma/titles/0004001000021B00/"
 				},
 				{
@@ -5243,7 +5243,7 @@
 				{
 					"type": "extractFile",
 					"file": "/SatellaZone.zip",
-					"input": "SatellaZone/",
+					"input": "",
 					"output": "/luma/titles/0004001000020B00/"
 				},
 				{


### PR DESCRIPTION
The local variant of SatellaZone was removed in a045f6e89b9c6989c28c441cf2ca29c30c67674e after the lite (server dependant) variant became the default. This pr adds it back.

In addition, the changes in ba8e67f6e0006f7edc8c9e5dfffd88a462a0b084 to fix the extraction of the archive was fixed upstream in `v2.1.1` and has the side effect of extracting just `romfs/www/SatellaZone/` instead of the entire archive. That is also reverted in this pr.