### PR TITLE
Prepare for move to org (SpotPassDumper9)

### DIFF
--- a/source/source.json
+++ b/source/source.json
@@ -6363,16 +6363,17 @@
 		"created": "2023-09-21T00:00:00Z"
 	},
 	{
-		"github": "MisterSheeple/SpotPassDumper9",
+		"github": "SpotPassArchive/SpotPassDumper9",
+		"author": "MisterSheeple",
 		"systems": ["3DS"],
 		"categories": ["utility", "firm"],
-		"icon": "https://raw.githubusercontent.com/MisterSheeple/SpotPassDumper9/master/assets/SpotPassDumper9-icon.png",
-		"image": "https://raw.githubusercontent.com/MisterSheeple/SpotPassDumper9/master/assets/SpotPassDumper9-banner.png",
+		"icon": "https://raw.githubusercontent.com/SpotPassArchive/SpotPassDumper9/master/assets/SpotPassDumper9-icon.png",
+		"image": "https://raw.githubusercontent.com/SpotPassArchive/SpotPassDumper9/master/assets/SpotPassDumper9-banner.png",
 		"scripts": {
 			"SpotPassDumper9.firm": [
 				{
 					"type": "downloadRelease",
-					"repo": "MisterSheeple/SpotPassDumper9",
+					"repo": "SpotPassArchive/SpotPassDumper9",
 					"file": "SpotPassDumper9_.*_Luma\\.zip",
 					"output": "/SpotPassDumper9.zip"
 				},
@@ -6381,12 +6382,6 @@
 					"file": "/SpotPassDumper9.zip",
 					"input": "SpotPassDumper9.firm$",
 					"output": "%FIRM%/SpotPassDumper9.firm"
-				},
-				{
-					"type": "extractFile",
-					"file": "/SpotPassDumper9.zip",
-					"input": "gm9/",
-					"output": "/gm9/"
 				},
 				{
 					"type": "deleteFile",


### PR DESCRIPTION
Also removed a step that's no longer necessary in new releases.

I'm creating this before doing the actual move to the org to ensure as little downtime as possible.