### PR TITLE
Update Art Path for Nazi Zombies: Portable

### DIFF
--- a/source/apps/nazi-zombies-portable.json
+++ b/source/apps/nazi-zombies-portable.json
@@ -9,8 +9,8 @@
 	"categories": [
 		"game"
 	],
-	"icon": "https://raw.githubusercontent.com/nzp-team/glquake/main/icon.png",
-	"image": "https://raw.githubusercontent.com/nzp-team/glquake/main/banner.png",
+	"icon": "https://raw.githubusercontent.com/nzp-team/vril-engine/main/source/ctr/art/icon.png",
+	"image": "https://raw.githubusercontent.com/nzp-team/vril-engine/main/source/ctr/art/banner.png",
 	"long_description": "A Quake-based \"demake\" of the 'Nazi Zombies' mode from Call of Duty: World at War.\n\nFeature-equivalent with Call of Duty: World at War on a generic level. Gameplay components are implemented, with minor parity differences. Most World at War maps and their gimmicks are not yet represented. Minor features from Call of Duty: Black Ops are also present.\n\nFeatures \"Nacht der Untoten\" and many maps created by the Community, bundled in.",
 	"download_filter": "3ds",
 	"scripts": {


### PR DESCRIPTION
I had moved the source for NZ:P to a new repository to consolidate some components with the game, and as a result the location of the art pulled by UU has changed.