### PR TITLE
Fix username for SuperHaxagon

### DIFF
--- a/source/apps/super-haxagon.json
+++ b/source/apps/super-haxagon.json
@@ -1,5 +1,5 @@
 {
-	"github": "RedInquisitive/Super-Haxagon",
+	"github": "RedTopper/Super-Haxagon",
 	"systems": [
 		"3DS"
 	],
@@ -9,6 +9,6 @@
 	"unique_ids": [
 		39338
 	],
-	"image": "https://raw.githubusercontent.com/RedInquisitive/Super-Haxagon/master/media/banner.png",
-	"icon": "https://raw.githubusercontent.com/RedInquisitive/Super-Haxagon/master/media/icon-3ds.png"
+	"image": "https://raw.githubusercontent.com/RedTopper/Super-Haxagon/master/media/banner.png",
+	"icon": "https://raw.githubusercontent.com/RedTopper/Super-Haxagon/master/media/icon-3ds.png"
 }


### PR DESCRIPTION
Hey!

I changed my username a long time ago, but I haven't been working on SuperHaxagon since then. I recently pushed a new update that fixes some bugs, so I figured I'd fix it over here.

I'm assuming it will pick up on the .cia and .3dsx automatically? There are a bunch of other platforms I release for (like switch, windows, linux) that don't need to be included on the 3ds.

Thanks!