### PR TITLE
dead-pixel-checker Removed trailing comma

### DIFF
--- a/source/apps/dead-pixel-checker.json
+++ b/source/apps/dead-pixel-checker.json
@@ -4,5 +4,5 @@
 	"systems": ["3DS"],
 	"categories": ["utility"],
 	"icon": "https://raw.githubusercontent.com/classyham/3DS_DeadPixelChecker/refs/heads/main/icon.png",
-	"long_description": "Cycles through colours to check for dead (sub)pixels",
+	"long_description": "Cycles through colours to check for dead (sub)pixels"
 }


### PR DESCRIPTION
removed trailing comma from dead-pixel-checker.json as generate.py was failing. Sorry for the issue, 