### PR TITLE
Select correct zip files for SuperHaxagon

### DIFF
--- a/source/apps/super-haxagon.json
+++ b/source/apps/super-haxagon.json
@@ -9,6 +9,19 @@
 	"unique_ids": [
 		39338
 	],
+	"long_description": "SuperHaxagon, like the original game Super Hexagon by Terry Cavanagh, has only one goal. Survive as long as possible by avoiding the falling walls in a trippy, spinny frenzy!",
 	"image": "https://raw.githubusercontent.com/RedTopper/Super-Haxagon/master/media/banner.png",
-	"icon": "https://raw.githubusercontent.com/RedTopper/Super-Haxagon/master/media/icon-3ds.png"
+	"icon": "https://raw.githubusercontent.com/RedTopper/Super-Haxagon/master/media/icon-3ds.png",
+	"archive": {
+		"SuperHaxagon-3DS-armhf.3dsx.zip": {
+			"SuperHaxagon.3dsx": [
+				"SuperHaxagon.3dsx"
+			]
+		},
+		"SuperHaxagon-3DS-armhf.cia.zip": {
+			"SuperHaxagon.cia": [
+				"SuperHaxagon.cia"
+			]
+		}
+	}
 }


### PR DESCRIPTION
Just a quick update to fetch the new archives for SuperHaxagon. I created a new build system using GitHub actions and to keep things consistent, I'm just going to upload the artifacts directly from the build.

I _think_ this is the proper way to do this. I just looked at some other files.

The .zips are structured flat like this:
```
SuperHaxagon.{cia,3dsx}
CREDITS.md
LICENSE.libs.md
LICENSE.md
```