### PR TITLE
Filter downloads for SuperHaxagon

### DIFF
--- a/source/apps/super-haxagon.json
+++ b/source/apps/super-haxagon.json
@@ -12,6 +12,7 @@
 	"long_description": "SuperHaxagon, like the original game Super Hexagon by Terry Cavanagh, has only one goal. Survive as long as possible by avoiding the falling walls in a trippy, spinny frenzy!",
 	"image": "https://raw.githubusercontent.com/RedTopper/Super-Haxagon/master/media/banner.png",
 	"icon": "https://raw.githubusercontent.com/RedTopper/Super-Haxagon/master/media/icon-3ds.png",
+	"download_filter": "SuperHaxagon-3DS-armhf\\.(3dsx|cia)\\.zip",
 	"archive": {
 		"SuperHaxagon-3DS-armhf.3dsx.zip": {
 			"SuperHaxagon.3dsx": [


### PR DESCRIPTION
Sorry to make another PR so soon, but the amount of releases I have these days pushes the 3DS builds off of the sites maximum download list.

<details>

<summary>Previous suggested Dockerfile changes, moved to #341</summary>

This time I tested it locally! Here's how I did it:

The Dockerfile is unfortunately currently broken because debian no longer let's you `pip install` outside of a venv as root. I worked around this by updating the dockerfile to this:
```Dockerfile
FROM devkitpro/devkitarm

MAINTAINER Pk11 <epicpkmn11@outlook.com>

RUN echo deb http://deb.debian.org/debian stable main contrib non-free >> /etc/apt/sources.list && \
    sudo apt-get update && \
    sudo apt-get install python3-pip python3.11-venv ruby ruby-dev -y

RUN gem install bundler jekyll

WORKDIR /opt/db

COPY source/requirements.txt /opt/db
ENV PATH="/opt/venv/bin:$PATH"
RUN mkdir -p /opt/venv && \
    python -m venv /opt/venv && \
    pip3 install -r /opt/db/requirements.txt

EXPOSE 4000
```
This installed both jekyll and the deps into the container (y'all probably don't want jekyll in there but it was great to have for testing). I then built ran the container with:
```bash
podman build --tag unidb -f Dockerfile
podman run --volume $(pwd):/opt/db:z -p 4000:4000 --rm -it localhost/unidb bash
```
and built the site following the README.md's instructions.

</details>

 It looks like this now:
![image](https://github.com/user-attachments/assets/b67f1baf-fe71-4912-956b-9e075745b972)
