### PR TITLE
Change Apotris archive regex so it can capture the release zip

### DIFF
--- a/source/apps/apotris.json
+++ b/source/apps/apotris.json
@@ -24,7 +24,7 @@
 		}
 	},
 	"archive": {
-		"Apotris-(.*-)?3(ds|DS)(-.*)?\\.zip": {
+		"Apotris-(.*)?3(ds|DS)(-.*)?\\.zip": {
 			"Apotris.3dsx + assets": [
 				"3ds/Apotris/assets/",
 				"3ds/Apotris/license/",


### PR DESCRIPTION
Users were reporting that installation was failing and it turns out the archive regex wasn't capturing the release zip file name