### PR TITLE
jksm: fix icon URL

### DIFF
--- a/source/apps/jksm.json
+++ b/source/apps/jksm.json
@@ -10,5 +10,5 @@
 	"unique_ids": [
 		180786
 	],
-	"icon": "https://raw.githubusercontent.com/J-D-K/JKSM/master/icon.png"
+	"icon": "https://raw.githubusercontent.com/J-D-K/JKSM/master/JKSM/icon.png"
 }


### PR DESCRIPTION
The app files were relocated to JKSM subfolder late november 2024