### PR TITLE
Update Art for Nazi Zombies: Portable (again)

### DIFF
--- a/source/apps/nazi-zombies-portable.json
+++ b/source/apps/nazi-zombies-portable.json
@@ -9,8 +9,8 @@
 	"categories": [
 		"game"
 	],
-	"icon": "https://raw.githubusercontent.com/nzp-team/vril-engine/main/source/ctr/art/icon.png",
-	"image": "https://raw.githubusercontent.com/nzp-team/vril-engine/main/source/ctr/art/banner.png",
+	"icon": "https://raw.githubusercontent.com/nzp-team/vril-engine/main/source/platform/ctr/art/icon.png",
+	"image": "https://raw.githubusercontent.com/nzp-team/vril-engine/main/source/platform/ctr/art/banner.png",
 	"long_description": "A Quake-based \"demake\" of the 'Nazi Zombies' mode from Call of Duty: World at War.\n\nFeature-equivalent with Call of Duty: World at War on a generic level. Gameplay components are implemented, with minor parity differences. Most World at War maps and their gimmicks are not yet represented. Minor features from Call of Duty: Black Ops are also present.\n\nFeatures \"Nacht der Untoten\" and many maps created by the Community, bundled in.",
 	"download_filter": "3ds",
 	"scripts": {


### PR DESCRIPTION
This is the same story as https://github.com/Universal-Team/db/pull/275, I recently did some refactoring which changed the location of the art assets UU is pointed to. Sorry for the trouble!