### PR TITLE
Switch to Click for CLI, add GitHub API wrapper, add singular app testing, switch path for pathlib

### DIFF
--- a/.github/workflows/update-priority.yml
+++ b/.github/workflows/update-priority.yml
@@ -26,7 +26,7 @@ jobs:
         WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}
       run: |
         export PATH=$PATH:/opt/devkitpro/tools/bin
-        python3 source/generate.py source/apps docs --priority
+        python3 source/generate.py all --priority
 
       # Pull origin in case a commit has been done while updating
     - name: Pull origin

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -23,7 +23,7 @@ jobs:
         WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}
       run: |
         export PATH=$PATH:/opt/devkitpro/tools/bin
-        python3 source/generate.py source/apps docs
+        python3 source/generate.py all
 
       # Pull origin in case a commit has been done while updating
     - name: Pull origin

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -17,7 +17,7 @@ services:
     image: docker.io/universalteam/db
     container_name: universal-db
     hostname: universal-db
-    command: python3 source/generate.py source/apps docs --priority
+    command: python3 source/generate.py all --priority
     environment:
       TOKEN: ${TOKEN}
       WEBHOOK_URL: ${WEBHOOK_URL}

--- a/source/requirements.txt
+++ b/source/requirements.txt
@@ -8,3 +8,4 @@ qrcode==6.1
 requests==2.32.2
 Unidecode==1.3.4
 discord.py==2.5.2
+click

--- a/source/utils.py
+++ b/source/utils.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import traceback
+from datetime import datetime, timezone
+from typing import Any, Dict
+
+from dateutil import parser
+from unidecode import unidecode
+
+
+def format_traceback(exc: Exception):
+	etype = type(exc)
+	trace = exc.__traceback__
+
+	return ''.join(traceback.format_exception(etype, exc, trace))
+
+
+def was_recently_updated(app: Dict[str, Any]) -> bool:
+	if "updated" not in app:
+		return False
+
+	last_updated = parser.parse(app["updated"])
+	days_since = (datetime.now(tz=timezone.utc) - last_updated).days
+	return days_since <= 30
+
+
+def get_matching_app(app: Dict[str, Any], old_data):
+	keys = [
+	    ("github", lambda x: x.get("github") == app.get("github")),
+	    ("gbatemp", lambda x: x.get("gbatemp") == app.get("gbatemp")),
+	    ("bitbucket", lambda x: x.get("bitbucket", {}).get("repo") == app.get("bitbucket", {}).get("repo")),
+	    ("title_author", lambda x: x.get("title") == app.get("title") and x.get("author") == app.get("author")),
+	    ("gitlab", lambda x: x.get("gitlab") == app.get("gitlab"))
+	]
+
+	for _, match_func in keys:
+		if matches := list(filter(match_func, old_data)):
+			return matches[0]
+	return None
+
+
+def format_to_web_name(name: str) -> str:
+	"""Convert names to lowercase alphanumeric, underscore, and hyphen"""
+	name = unidecode(name).lower()
+	out = ""
+	for letter in name:
+		if letter in "abcdefghijklmnopqrstuvwxyz0123456789-_":
+			out += letter
+		elif letter in ". ":
+			out += "-"
+	return out
+
+
+def to_friendly_bytes(bytes: int) -> str:
+	"""Converts an int number of bytes to a str with the largest appropriate unit"""
+	if bytes == 1:
+		return "1 Byte"
+	elif bytes < (1 << 10):
+		return f"{bytes} Bytes"
+	elif bytes < (1 << 20):
+		return f"{bytes // (1 << 10)} KiB"
+	elif bytes < (1 << 30):
+		return f"{bytes // (1 << 20)} MiB"
+	else:
+		return f"{bytes // (1 << 30)} GiB"


### PR DESCRIPTION
A summary of the changes:

- Argparse was switched out with click instead.
- A small wrapper for the GitHub API was made to make certain operations easier to use and reduce duplication.
- A way to test singular apps was added and can be accessed in the CLI via the app-test command.
- Lots of the code use path which is not very pythonic, so it got switched out with pathlib
- A few common functions were moved to a new utils.py file

I have updated the workflow files to adjust for the new CLI command changes