### PR TITLE
Fixup FourthTube entry.

### DIFF
--- a/source/apps/fourthtube.json
+++ b/source/apps/fourthtube.json
@@ -12,5 +12,5 @@
 	"icon": "https://raw.githubusercontent.com/erievs/FourthTube/main/resource/icon.png",
 	"image": "https://raw.githubusercontent.com/erievs/FourthTube/main/resource/banner_legacy.png",
 	"license": "gpl-3.0",
-	"license_name": "GNU General Public License v3.0 or later"
+	"license_name": "GNU General Public License v3.0"
 }

--- a/source/apps/fourthtube.json
+++ b/source/apps/fourthtube.json
@@ -10,5 +10,7 @@
 		784205
 	],
 	"icon": "https://raw.githubusercontent.com/erievs/FourthTube/main/resource/icon.png",
-	"image": "https://raw.githubusercontent.com/erievs/FourthTube/main/resource/banner_legacy.png"
+	"image": "https://raw.githubusercontent.com/erievs/FourthTube/main/resource/banner_legacy.png",
+	"license": "gpl-3.0",
+	"license_name": "GNU General Public License v3.0 or later"
 }

--- a/source/apps/fourthtube.json
+++ b/source/apps/fourthtube.json
@@ -10,5 +10,5 @@
 		784205
 	],
 	"icon": "https://raw.githubusercontent.com/erievs/FourthTube/main/resource/icon.png",
-	"image": "https://raw.githubusercontent.com/erievs/FourthTube/main/resource/banner.png"
+	"image": "https://raw.githubusercontent.com/erievs/FourthTube/main/resource/banner_legacy.png"
 }


### PR DESCRIPTION
Turns out I renamed banner.png to banner_legacy.png (we have a 3D one now, and the old, 2D one is now this) without knowing it was being used here. Oops.

While I'm here, also add some license info.