### PR TITLE
Fix CTGP-7 download address

### DIFF
--- a/source/apps/ctgp-7-downloader.json
+++ b/source/apps/ctgp-7-downloader.json
@@ -27,7 +27,7 @@
 	},
 	"downloads": {
 		"CTGP-7_Downloader.cia": {
-			"url": "https://ctgp7.page.link/cia_downloader"
+			"url": "https://imaginye.ddns.net:7777/l/cia_downloader"
 		}
 	}
 }


### PR DESCRIPTION
The old CTGP-7 download link used Google Dynamic Links, which has shut down. This PR fixes the address of the CTGP-7 downloader to the new dynamic links implementation hosted in the CTGP-7 server itself.