### PR TITLE
Fix CIA Installer categories

### DIFF
--- a/source/apps/cia-installer.json
+++ b/source/apps/cia-installer.json
@@ -2,7 +2,7 @@
 	"github": "Zachary-Rude/CIA-Installer",
 	"title": "CIA Installer",
 	"systems": ["3DS"],
-	"categories": ["game"],
+	"categories": ["app", "utility"],
 	"unique_ids": [570900],
 	"image": "https://raw.githubusercontent.com/Zachary-Rude/CIA-Installer/refs/heads/main/app/banner.png",
 	"icon": "https://raw.githubusercontent.com/Zachary-Rude/CIA-Installer/refs/heads/main/app/icon.png"


### PR DESCRIPTION
My [CIA Installer](https://github.com/Zachary-Rude/CIA-Installer) app recently got added to Universal-DB, but it is currently categorized incorrectly as a game. This pull request fixes that by changing its categories to app and utility.