### PR TITLE
Add IP-Cam Viewer for 3DS/2DS

### DIFF
--- a/apps/ipwebcamviewer.json
+++ b/apps/ipwebcamviewer.json
@@ -1,0 +1,24 @@
+{
+  "version": 3,
+  "storeInfo": {
+    "name": "IP-Cam Viewer",
+    "file": "ipcamviewer.json",
+    "sheet": "ipcamviewer.smdh",
+    "bg_index": "null",
+    "bg_sheet": "null",
+    "authors": ["Alti"],
+    "categories": ["Utility"],
+    "consoles": ["3ds"]
+  },
+  "storeContent": [
+    {
+      "version": "1.0.0",
+      "title": "IP-Cam Viewer",
+      "description": "A proof-of-concept 3DS homebrew app to view IP camera streams.",
+      "url": "https://github.com/MC-Gaming-59o/Homebrew-3DS-IP-Webcam-Viewer/releases/download/v0.1beta/ipwebcv.3dsx",
+      "icon": "https://github.com/MC-Gaming-59o/Homebrew-3DS-IP-Webcam-Viewer/releases/download/v0.1beta/icon.jpg",
+      "promptMessage": "Press A to install IP-Cam Viewer.",
+      "exit": true
+    }
+  ]
+}


### PR DESCRIPTION
# IP-Cam Viewer for 3DS/2DS

## Overview
IP-Cam Viewer is a 3DS/2DS homebrew app that allows users to view live video streams from Android devices running IP Webcam or IP Webcam Pro. Originally created as a proof-of-concept, it is now in active Beta development. Future updates may come over the next months, although the current version is already functional and stable for basic use.

## Requirements
- 3DS or 2DS with Homebrew Launcher
- Android device with IP Webcam or IP Webcam Pro installed
- Network access (Wi-Fi)
- Recommended resolution: 320×240 for both screens (upper screen will display 320×240 even though native is 400×240)

## Features
- Live video streaming from IP Webcam devices
- Torch control (if supported by the host)
- LSD-/Mushroom-Mode: press Select to swap the byte order for a colorful, trippy effect (running gag)
- Proof-of-Concept evolved into Beta

## Known Issues
- Flash function (press X) may hang on the first attempt. Rebooting can temporarily fix it, but it might fail again on subsequent reboots. This bug will be fixed in a future update.

## Notes
- Beta software; minor bugs or instability may occur
- Only compatible with IP Webcam / IP Webcam Pro
- Recommended resolution is 320×240; higher resolutions are supported but not required
