### PR TITLE
Add 3DS Random Game Launcher

### DIFF
--- a/source/apps/3ds-random-game-laucher.json
+++ b/source/apps/3ds-random-game-laucher.json
@@ -1,0 +1,9 @@
+{
+  "github": "selloa/3DS-Random-Game-Launcher",
+  "systems": ["3DS"],
+  "categories": ["utility"],
+  "unique_ids": [0],
+  "image": "https://raw.githubusercontent.com/selloa/3DS-Random-Game-Launcher/main/meta/banner.png",
+  "icon": "https://raw.githubusercontent.com/selloa/3DS-Random-Game-Launcher/main/icon.png",
+  "long_description": "Can't decide what to play? Let your 3DS pick for you! This utility scans your SD card, filters out system junk, and launches a random game from your library. Perfect for indecisive gamers who want to discover forgotten titles.\n\n**Features:**\n- Scans all installed games on your SD card\n- Filters out system applications and junk\n- Random game selection with reroll option\n- Homebrew mode toggle (X button)\n- Simple controls: A to launch, Y to reroll, START to exit\n- Database of 4,135+ 3DS game titles with proper names\n\n**Controls:**\n- `A` - Launch the selected title\n- `Y` - Reroll for something else  \n- `X` - Toggle homebrew mode\n- `START` - Exit\n\nBuilt with libctru and includes a comprehensive title database sourced from 3dsdb community data."
+}


### PR DESCRIPTION
## <img width="48" height="48" alt="icon" src="https://github.com/user-attachments/assets/2a96d446-b69d-43d4-8e46-b3618d9ccdd4" /> 3DS Random Game Launcher 

A utility app that helps indecisive gamers by randomly selecting and launching games from their 3DS library.

<img width="256" height="128" alt="banner" src="https://github.com/user-attachments/assets/d4728630-9c7b-407b-80a6-f5a003febfd2" />

### Features
- Scans all installed games on SD card
- Filters out system applications and junk
- Random game selection with reroll option
- Homebrew mode toggle (X button)
- Database of 4,135+ 3DS game titles with proper names
<img width="400" height="240" alt="screenshot" src="https://github.com/user-attachments/assets/3eac9cd5-87ed-4ed4-8c53-71214af6d7ba" />

### Controls
- A - Launch selected title
- Y - Reroll for something else
- X - Toggle homebrew mode
- START - Exit

### Assets
- Banner: https://raw.githubusercontent.com/selloa/3DS-Random-Game-Launcher/main/meta/banner.png

- Screenshot: https://raw.githubusercontent.com/selloa/3DS-Random-Game-Launcher/main/meta/screenshot.png


- Icon: https://raw.githubusercontent.com/selloa/3DS-Random-Game-Launcher/main/icon.png

Built with libctru and includes comprehensive title database sourced from 3dsdb community data.