### PR TITLE
Remove numbers from carousel indicators

### DIFF
--- a/docs/_layouts/app.html
+++ b/docs/_layouts/app.html
@@ -216,11 +216,11 @@ layout: compress
 										<div class="col-12">
 											<h2 class="i18n innerHTML-screenshots">Screenshots</h2>
 											<div id="screenshotCarousel" class="carousel carousel-dark-when-light slide mb-3" data-bs-ride="carousel">
-												<ol class="carousel-indicators">
+												<div class="carousel-indicators">
 													{% for ss in page.screenshots %}
-														<li data-bs-target="#screenshotCarousel" data-bs-slide-to="{{ forloop.index0 }}" class="{% if forloop.first %}active{% endif %}"></li>
+														<button type="button" data-bs-target="#screenshotCarousel" data-bs-slide-to="{{ forloop.index0 }}" class="{% if forloop.first %}active{% endif %}"></button>
 													{% endfor %}
-												</ol>
+												</div>
 												<div class="carousel-inner">
 													{% for ss in page.screenshots %}
 														<div class="carousel-item mt-2 mb-2 {% if forloop.first %}active{% endif %}">

--- a/docs/assets/css/light.scss
+++ b/docs/assets/css/light.scss
@@ -40,6 +40,6 @@ $light-placeholder: darkgray;
 	filter: invert(1) grayscale(100);
 }
 
-.carousel-dark-when-light .carousel-indicators li {
+.carousel-dark-when-light .carousel-indicators button {
 	background-color: #000;
 }


### PR DESCRIPTION
With a recent bootstrap update, it seems as though using an ordered list to display the carousel indicators will add numbers next to them:

<img width="567" height="48" alt="image" src="https://github.com/user-attachments/assets/c5d63e6d-757e-4a34-9385-37d8c19cfe99" />

It looks quite odd as the numbers do not align with the indicators; I think it would look better if they were removed. I replaced the ordered list with a div and list items with buttons as is done in the [documentation](https://getbootstrap.com/docs/5.3/components/carousel/#indicators). Here is what that looks like with that change:

<img width="567" height="48" alt="image" src="https://github.com/user-attachments/assets/ee9b865b-5136-4253-b03d-4e9df22032b3" />
