### PR TITLE
Add "Better-NFCReader"

### DIFF
--- a/source/apps/better-nfcreader.json
+++ b/source/apps/better-nfcreader.json
@@ -6,7 +6,7 @@
 	"systems": ["3DS"],
 	"categories": ["utility"],
 	"unique_ids": [771177],
-	"image": "https://raw.githubusercontent.com/cylin577/Better-NFCReader/main/resources/banner.png",
-	"icon": "https://raw.githubusercontent.com/cylin577/Better-NFCReader/main/resources/icon.png",
+	"image": "https://raw.githubusercontent.com/cylin577/Better-NFCReader/master/resources/banner.png",
+	"icon": "https://raw.githubusercontent.com/cylin577/Better-NFCReader/master/resources/icon.png",
 	"long_description": "This is a really cool app based on MrJPGames' NFCReader, I updated it to citro2d and make it possible to scan 0x7 tags."
 }


### PR DESCRIPTION
This app can read 0x7 NFC/RFID tags using 3DS' hardware, this is compatible for ALL 3DS (execpt O2DS)
I have 3dsx, smdh, and cia in the release seprated

Btw, I already checked the .json file by using ```python generate.py app-test-command apps/better-nfcreader.json``` and it passed the checks