### PR TITLE
Magic Draw: Remove script_message

### DIFF
--- a/source/apps/magic-draw.json
+++ b/source/apps/magic-draw.json
@@ -12,6 +12,5 @@
 	"image": "https://raw.githubusercontent.com/natsuneco/magic-draw/refs/heads/main/meta/banner.png",
 	"unique_ids": [
 		847908
-	],
-	"script_message": "Note: It may not work on the old3DS at this time."
+	]
 }


### PR DESCRIPTION
I have removed the script_message as the functionality has been confirmed on the old3DS.