### PR TITLE
Add PandaFlow

### DIFF
--- a/source/apps/pandaflow.json
+++ b/source/apps/pandaflow.json
@@ -1,0 +1,11 @@
+{
+	"github": "PandaAkiraNakai/PandaFlow",
+	"systems": [
+		"3DS"
+	],
+	"categories": [
+		"app"
+	],
+	"icon": "https://raw.githubusercontent.com/PandaAkiraNakai/PandaFlow/main/meta/icon.png",
+	"long_description": "Homebrew music player for the Nintendo 3DS that keeps playing with the lid closed (like the official 3DS Sound app). Plays MP3, FLAC, WAV and AAC organized into album folders, with cover art, synced .lrc / plain .txt lyrics, shuffle and repeat, and a touch transport bar. Mixtape-style UI with a spinning vinyl record. On New 3DS the C-stick adjusts the volume."
+}


### PR DESCRIPTION
Adds **PandaFlow**, a homebrew music player for the Nintendo 3DS.

- Repo: https://github.com/PandaAkiraNakai/PandaFlow
- Release with a direct `.3dsx` asset: https://github.com/PandaAkiraNakai/PandaFlow/releases/tag/v1.0.0
- Open source (GPLv2). Plays MP3/FLAC/WAV/AAC by album folders, cover art, `.lrc`/`.txt` lyrics, shuffle/repeat, keeps playing with the lid closed.

I am the app developer. The request complies with the Universal-DB guidelines.