### PR TITLE
Add 3ds-fastfetch

### DIFF
--- a/source/apps/3ds-fastfetch.json
+++ b/source/apps/3ds-fastfetch.json
@@ -1,0 +1,11 @@
+{
+	"github": "xPsycho999/3ds-fastfetch",
+	"systems": [
+		"3DS"
+	],
+	"categories": [
+		"utility"
+	],
+	"image": "https://raw.githubusercontent.com/xPsycho999/3ds-fastfetch/main/icons/iconA_device_big.png",
+	"icon": "https://raw.githubusercontent.com/xPsycho999/3ds-fastfetch/main/icons/iconA_device.png"
+}


### PR DESCRIPTION
Adds **3ds-fastfetch**, a fastfetch-style system information tool for the Nintendo 3DS.

- Repo: https://github.com/xPsycho999/3ds-fastfetch
- License: GPL-3.0
- Release with `.3dsx`: https://github.com/xPsycho999/3ds-fastfetch/releases/tag/v1.0.0

It displays only values actually read from the console (model, region, language, serial, OS/CFW/kernel, CPU, screens, battery, storage, Wi-Fi, MAC, etc.), with a model-specific ASCII logo. `.3dsx`-only, so no `unique_ids`.