### PR TITLE
DSFetch

### DIFF
--- a/source/apps/DSFetch.json
+++ b/source/apps/DSFetch.json
@@ -1,0 +1,11 @@
+{
+	"github": "xPsycho999/DSFetch",
+	"systems": [
+		"DS"
+	],
+	"categories": [
+		"utility"
+	],
+	"image": "https://raw.githubusercontent.com/xPsycho999/DSFetch/main/icons/banner.png",
+	"icon": "https://raw.githubusercontent.com/xPsycho999/DSFetch/main/icons/icon.png"
+}


### PR DESCRIPTION
Adds DSFetch, a fastfetch-style system information tool for the Nintendo DS and DSi (built with libnds). Public GPLv3 source and a v1.0.0 GitHub Release with the .nds are available. Port of 3ds-fastfetch.