### PR TITLE
Add Meteo3DS

### DIFF
--- a/source/apps/meteo3ds.json
+++ b/source/apps/meteo3ds.json
@@ -1,0 +1,14 @@
+{
+	"github": "xPsycho999/Meteo3DS",
+	"systems": [
+		"3DS"
+	],
+	"categories": [
+		"app"
+	],
+	"unique_ids": [
+		994394
+	],
+	"image": "https://raw.githubusercontent.com/xPsycho999/Meteo3DS/main/cia/banner.png",
+	"icon": "https://raw.githubusercontent.com/xPsycho999/Meteo3DS/main/icon.png"
+}


### PR DESCRIPTION
Adds **Meteo3DS**, a polished bilingual (EN/DE) weather app for the Nintendo 3DS.

- Repo: https://github.com/xPsycho999/Meteo3DS (GPL-3.0, public source)
- Powered by the free, key-less [Open-Meteo](https://open-meteo.com/) API over plain HTTP
- Features: live current conditions, hourly temperature graph, 7-day forecast, air quality (EU AQI, PM2.5/PM10) + pollen, multiple cities, animated vector icons, per-condition day/night themes, Wi-Fi indicator
- Ships both `.cia` (with `unique_ids`) and `.3dsx` via GitHub Releases (latest: v1.0.1)

Complies with the contribution rules: no copyrighted content, no NSFW, has a description (README), meaningful functionality, original project (not a fork), and is for the 3DS.
