### PR TITLE
Add MPR Connect

### DIFF
--- a/source/apps/mpr-connect.json
+++ b/source/apps/mpr-connect.json
@@ -1,0 +1,12 @@
+{
+	"github": "taxicat1/mpr-connect",
+	"title": "MPR Connect",
+	"systems": [
+		"DS"
+	],
+	"categories": [
+		"utility"
+	],
+	"llm_generation": "no",
+	"icon": "https://raw.githubusercontent.com/taxicat1/mpr-connect/main/resource/icon48.png"
+}


### PR DESCRIPTION
Adds MPR Connect, a DS tool to connect a physical cartridge of Pokemon Diamond, Pearl, or Platinum to My Pokemon Ranch on the Wii.

Importantly this removes the RSA signature check that normally takes place during the connection. This is required in order to connect to the pending fan translation of the Platinum update patch