### PR TITLE
Add freeciv3ds

### DIFF
--- a/source/apps/freeciv3ds.json
+++ b/source/apps/freeciv3ds.json
@@ -1,0 +1,12 @@
+{
+	"github": "xPsycho999/freeciv3ds",
+	"systems": [
+		"3DS"
+	],
+	"categories": [
+		"game"
+	],
+	"llm_generation": "yes",
+	"image": "https://raw.githubusercontent.com/xPsycho999/freeciv3ds/main/icons/icon-big.png",
+	"icon": "https://raw.githubusercontent.com/xPsycho999/freeciv3ds/main/icons/icon.png"
+}


### PR DESCRIPTION
Adds Freeciv 3DS, a New 3DS homebrew port of Freeciv (open-source Civilization-style strategy game). Server core cross-compiled to ARM11, custom citro2d client, runs in-process with no network client. LLM usage: yes (declared per policy).