### PR TITLE
Add Block Blast 3DS

### DIFF
--- a/source/apps/block-blast-3ds.json
+++ b/source/apps/block-blast-3ds.json
@@ -1,0 +1,15 @@
+{
+	"github": "TheFilipcom4607/BlockBlast-3DS",
+	"title": "Block Blast 3DS",
+	"systems": [
+		"3DS"
+	],
+	"categories": [
+		"game"
+	],
+	"unique_ids": [
+		1047322
+	],
+	"image": "https://raw.githubusercontent.com/TheFilipcom4607/BlockBlast-3DS/main/meta/banner.png",
+	"icon": "https://raw.githubusercontent.com/TheFilipcom4607/BlockBlast-3DS/main/icon.png"
+}

--- a/source/apps/block-blast-3ds.json
+++ b/source/apps/block-blast-3ds.json
@@ -7,6 +7,7 @@
 	"categories": [
 		"game"
 	],
+	"llm_generation": "yes",
 	"unique_ids": [
 		1047322
 	],


### PR DESCRIPTION
Adds Block Blast 3DS, a homebrew Block Blast for the 3DS family.

- Repo: https://github.com/TheFilipcom4607/BlockBlast-3DS
- Latest release `V1.3` has both `blockblast.cia` and `blockblast.3dsx` attached as bare assets, so no `archive` block is needed
- Licensed zlib
- `unique_ids` is `1047322` (`0xFFB1A`, from title ID `000400000FFB1A00`) so an installed copy is detected and updated in place
- `image` is the 256x128 HOME menu banner and `icon` is the 48x48 SMDH icon, both from the repo
- Board on the top screen, tray and aiming grid on the touch screen, stereoscopic 3D on the top screen. Every graphic and sound is generated at runtime, no assets or romfs

It is an unofficial fan project, not affiliated with or endorsed by Hungry Studio, and shares no code or assets with the original game.
