### PR TITLE
add VirtuaNES Download Play

### DIFF
--- a/source/apps/emus3ds-download-play.json
+++ b/source/apps/emus3ds-download-play.json
@@ -1,12 +1,14 @@
 {
-	"github": "bOOt3r/emus3ds-download-play",
-	"systems": [
-		"3DS"
-	],
-	"categories": [
-		"emulator"
-	],
-	"llm_generation": "yes",
-	"icon": "https://raw.githubusercontent.com/bOOt3r/emus3ds-download-play/main/virtuanes_3ds_top.png",
-	"long_description": "VirtuaNES for 3DS with Download Play support for local multiplayer."
+    "github": "bOOt3r/emus3ds-download-play",
+    "title": "VirtuaNES Download Play",
+    "systems": [
+        "3DS"
+    ],
+    "categories": [
+        "emulator"
+    ],
+    "llm_generation": "yes",
+    "icon": "https://raw.githubusercontent.com/bOOt3r/emus3ds-download-play/main/src/cores/virtuanes/assets/icon.png",
+    "image": "https://raw.githubusercontent.com/bOOt3r/emus3ds-download-play/main/virtuanes_3ds_top.png",
+    "long_description": "VirtuaNES for the whole 2DS and 3DS family with local wireless multiplayer support. System A Hosts and system B Joins, it's as easy as pie!"
 }

--- a/source/apps/emus3ds-download-play.json
+++ b/source/apps/emus3ds-download-play.json
@@ -1,0 +1,12 @@
+{
+	"github": "bOOt3r/emus3ds-download-play",
+	"systems": [
+		"3DS"
+	],
+	"categories": [
+		"emulator"
+	],
+	"llm_generation": "yes",
+	"icon": "https://raw.githubusercontent.com/bOOt3r/emus3ds-download-play/main/virtuanes_3ds_top.png",
+	"long_description": "VirtuaNES for 3DS with Download Play support for local multiplayer."
+}


### PR DESCRIPTION
VirtuaNES Download Play is the VirtuaNES we all love with something extra - Download Play!
Load the emulator on two systems, it supports all flavours of 2DS and 3DS, system 1 hosts the rom and system 2 joins.
It's as easy as.. pie!

Source repo:
https://github.com/bOOt3r/emus3ds-download-play

Release asset:
https://github.com/bOOt3r/emus3ds-download-play/releases