### PR TITLE
Add CTGP-7 Mod Manager

### DIFF
--- a/source/apps/ctgp-7-mod-manager.json
+++ b/source/apps/ctgp-7-mod-manager.json
@@ -1,0 +1,21 @@
+{
+	"github": "NitroShellMKDS/CTGP-7-Mod-Manager",
+	"title": "CTGP-7 Mod Manager",
+	"description": "Homebrew application for managing mods from GameBanana for CTGP-7.",
+	"author": "NitroShell and Contributors",
+	"systems": [
+		"3DS"
+	],
+	"categories": [
+		"utility",
+		"app"
+	],
+	"llm_generation": "minor",
+	"icon": "https://raw.githubusercontent.com/NitroShellMKDS/CTGP-7-Mod-Manager/refs/heads/main/app/icon.png",
+	"image": "https://raw.githubusercontent.com/NitroShellMKDS/CTGP-7-Mod-Manager/refs/heads/main/assets/logo.png",
+	"unique_ids": [
+		982398
+	],
+	"long_description": "Nintendo 3DS homebrew application for easily installing, updating, and uninstalling mods from GameBanana for CTGP-7.",
+	"wiki": "https://gbatemp.net/threads/ctgp-7-mod-manager-a-mod-manager-for-ctgp-7-on-3ds.683712/"
+}


### PR DESCRIPTION
Adds CTGP-7 Mod Manager, a mod manager for CTGP-7 on the Nintendo 3DS.

Source Repo: https://github.com/NitroShellMKDS/CTGP-7-Mod-Manager
GBATemp Article: https://gbatemp.net/threads/ctgp-7-mod-manager-a-mod-manager-for-ctgp-7-on-3ds.683712/

It uses some LMM assistance when things were broken and we couldn't fix the code we had some help from a local LLM, no other assets were generated. LLM content has been reviewed thoroughly.

The releases page only has a .3dsx file since the .cia version has a banner bug, as soon as this is fixed it will be in the v1.0 release.

Please pull this commit soon, the trailer is being worked on and I need it pulled soon so that I can release the trailer.