### PR TITLE
Update aurorachat.json to point to the proper repository

### DIFF
--- a/source/apps/aurorachat.json
+++ b/source/apps/aurorachat.json
@@ -1,11 +1,11 @@
 
 {
-	"github": "Unitendo/aurorachat",
-	"author": "Unitendo",
+	"github": "Unitendo/aurorachat-3ds",
+	"author": "Startendo",
 	"systems": ["3DS"],
 	"categories": ["app"],
   	"unique_ids": [765906],
 	"image": "https://raw.githubusercontent.com/Unitendo/aurorachat-3ds/main/meta/banner.png",
 	"icon": "https://raw.githubusercontent.com/Unitendo/aurorachat-3ds/main/meta/icon.png",
-	"long_description": "A safer chatting app for the Nintendo 3DS line of systems."
+	"long_description": "A chatting app primarily for Homebrewed Nintendo consoles."
 }


### PR DESCRIPTION
An issue for a long time that has been bothering me for a while is that the 3DS releases grab from Unitendo/aurorachat instead of Unitendo/aurorachat-3ds, this pull request fixes that oversight.

Additionally, since Unitendo had the plug pulled for a short amount of time before a bunch of ownership changes and a lot of other things happening, the name has officially changed to Startendo, especially since the original Unitendo name does not exactly fit the project as well anymore. The actual organization name has not yet changed though, so the Unitendo/repo links are kept in this pull request.

I also touched up the description a bit to make more sense.

Have a good one!