### PR TITLE
Add N3DS Weather and DarkSec Chat (3DS)

### DIFF
--- a/source/apps/darksec-chat.json
+++ b/source/apps/darksec-chat.json
@@ -1,0 +1,32 @@
+{
+	"title": "DarkSec Chat",
+	"author": "DarkSec",
+	"description": "Live chat client for darksec.uk",
+	"long_description": "A native Nintendo 3DS homebrew client for the live chat at [darksec.uk/chat](https://darksec.uk/chat).\n\nThe top screen shows the live message log; the bottom screen is a touch terminal keyboard for sending messages. Fully native 3DS controls with scroll, handle entry and a persistent connection.\n\n* Live log on the top screen\n* Touch keyboard terminal on the bottom screen\n* Scroll with UP / DOWN, handle with SELECT\n* Auto-reconnect",
+	"website": "https://darksec.uk/3ds",
+	"systems": ["3DS"],
+	"categories": ["utility"],
+	"unique_ids": [1018391],
+	"version": "v1.0.0",
+	"updated": "2026-09-02T07:26:00Z",
+	"image": "https://darksec.uk/3ds/chat-banner.png",
+	"icon": "https://darksec.uk/3ds/chat-icon.png",
+	"license": "MIT",
+	"license_name": "MIT License",
+	"color": "#6c5ce7",
+	"downloads": {
+		"darksec-chat.zip": {
+			"url": "https://darksec.uk/3ds/darksec-chat.zip"
+		}
+	},
+	"archive": {
+		"darksec-chat\\.zip": {
+			"DarkSec Chat (.cia)": [
+				"darksecchat.cia"
+			],
+			"DarkSec Chat (.3dsx)": [
+				"darksecchat.3dsx"
+			]
+		}
+	}
+}

--- a/source/apps/n3ds-weather.json
+++ b/source/apps/n3ds-weather.json
@@ -1,0 +1,32 @@
+{
+	"title": "N3DS Weather",
+	"author": "DarkSec",
+	"description": "Live 3D weather for the New 3DS XL",
+	"long_description": "A modern weather app for the New 3DS XL. The top screen is an animated **stereoscopic 3D** scene of the current conditions - drifting clouds, rain, snow and storm lightning - and the bottom screen is the full forecast: a 7-day strip, hour-by-hour detail, city search and Celsius/Fahrenheit toggle.\n\n* Top screen: live 3D weather scene (rain / snow / storm / sun / stars)\n* Bottom screen: current conditions + 7-day + hourly forecast\n* City search with an on-screen keyboard\n* Alerts derived from the forecast (wind, storms, heat)\n* Settings and location save to the SD card\n* Data from [Open-Meteo](https://open-meteo.com), no account needed",
+	"website": "https://darksec.uk/3ds",
+	"systems": ["3DS"],
+	"categories": ["utility"],
+	"unique_ids": [320675],
+	"version": "v1.0.0",
+	"updated": "2026-09-02T10:53:00Z",
+	"image": "https://darksec.uk/3ds/banner.png",
+	"icon": "https://darksec.uk/3ds/icon.png",
+	"license": "MIT",
+	"license_name": "MIT License",
+	"color": "#2e86de",
+	"downloads": {
+		"n3ds-weather.zip": {
+			"url": "https://darksec.uk/3ds/n3ds-weather.zip"
+		}
+	},
+	"archive": {
+		"n3ds-weather\\.zip": {
+			"N3DS Weather (.cia)": [
+				"n3ds-weather.cia"
+			],
+			"N3DS Weather (.3dsx)": [
+				"n3ds-weather.3dsx"
+			]
+		}
+	}
+}


### PR DESCRIPTION
Adds two Nintendo 3DS homebrew utility apps to the database.

**N3DS Weather** — live 3D weather app for the New 3DS XL. Top screen is an animated stereoscopic 3D scene of current conditions; bottom screen is the 7-day + hourly forecast, city search and C/F toggle. Data from Open-Meteo, settings saved to SD. Unique ID 0x4E4A3 (320675).

**DarkSec Chat** — native 3DS client for the live chat at darksec.uk/chat. Live log on top, touch keyboard terminal on bottom. Unique ID 0xF8A17 (1018391).

Both apps are hosted at https://darksec.uk/3ds (no GitHub release API, so manual `downloads` + `archive` entries are used, matching the Apotris pattern).